### PR TITLE
Improve TokenConfig type check in cleanSheetTabs

### DIFF
--- a/module/src/cleaner-sheet-title-bar.js
+++ b/module/src/cleaner-sheet-title-bar.js
@@ -46,7 +46,7 @@ function cleanDocumentHeader(app, html) {
 }
 
 function cleanSheetTabs(app, html) {
-    if (!(app instanceof TokenConfig)
+    if (!(app instanceof foundry.applications.sheets.TokenConfig)
         || !html
         || !game.settings.get("cleaner-sheet-title-bar", "collapse-navbars")) return;
 


### PR DESCRIPTION
Updated the type check in cleanSheetTabs to use foundry.applications.sheets.TokenConfig instead of TokenConfig, ensuring compatibility with Foundry VTT's class structure and preventing potential type mismatches.